### PR TITLE
Include listening to port 443 and mark requests as https

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,5 +9,7 @@ COPY nginx.tmpl /etc/nginx/
 COPY conf.d /etc/nginx/conf.d
 COPY docker-entrypoint.sh /
 
+EXPOSE 80 443
+
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD []

--- a/conf.d/default.tmpl
+++ b/conf.d/default.tmpl
@@ -8,11 +8,17 @@ map $http_upgrade $proxy_connection {
     '' close;
 }
 
+# Force https scheme when connected to port 443
+map $server_port $http_scheme_to_use {
+  default $scheme;
+  443 https;
+}
+
 # If we receive X-Forwarded-Proto, pass it through; otherwise, pass along the
 # scheme used to connect to this server
 map $http_x_forwarded_proto $proxy_x_forwarded_proto {
     default $http_x_forwarded_proto;
-    '' $scheme;
+    '' $http_scheme_to_use;
 }
 
 # Set appropriate X-Forwarded-Ssl header
@@ -20,7 +26,6 @@ map $scheme $proxy_x_forwarded_ssl {
     default off;
     https on;
 }
-
 
 # If we receive X-Forwarded-Port, pass it through; otherwise, pass along the
 # server port the client connected to


### PR DESCRIPTION
TLS termination happens at the load balancer but might not set the
appropriate headers (such as AWS network load balancers) so we have to
mark it based on port.